### PR TITLE
支持 Nuxt SSR

### DIFF
--- a/src/plugin/waterfall/README.md
+++ b/src/plugin/waterfall/README.md
@@ -71,3 +71,61 @@ breakpoints: {
   }
 }
 ```
+
+### SSR(服务端渲染支持)
+支持基于 Nuxt 的服务端渲染（SSR），目的是为了更好的 SEO。
+
+原理为在服务端借助拿到的模板与数据渲染出子元素，等到客户端再计算布局。
+
+要支持 Nuxt 的 SSR，需要将 Waterfall 作为一个插件（plugin）：
+
+```javascript
+// plugins/vue-waterfall.js
+
+import Vue from 'vue'
+import Waterfall from '~/vendors/waterfall/Waterfall';
+
+// 注入到 Vue 中作为全局组件
+Vue.component('Waterfall', Waterfall)
+
+```
+
+并在 `nuxt.config.js` 中注册，此时可以设置 `ssr` 为 true：
+
+````javascript
+// nuxt.config.js
+
+export default {
+  	plugins: [
+      // ...
+      {src: '~/plugins/vue-waterfall.js', ssr: true}
+    ]
+}
+````
+
+之后可以在组件中使用：
+
+```vue
+// your/component.vue
+<template>
+	<Waterfall :list="list" />
+</template>
+
+<script>
+  export default{
+    asyncData(){
+      const data = requestData()
+      // 这样在 SSR 阶段就能渲染列表数据，但是布局计算是在客户端完成的。
+      // 目的是为了 SEO 优化。
+      return {
+        list: data
+      }
+    },
+    data(){
+      return {
+        list: []
+      }
+    }
+  }
+</script>
+```

--- a/src/plugin/waterfall/lib/utils/dom.js
+++ b/src/plugin/waterfall/lib/utils/dom.js
@@ -19,8 +19,12 @@ export function removeClass(el, className) {
     el.className = newClass.join(' ');
   }
 }
-
-const elementStyle = document.createElement('div').style;
+let elementStyle = null;
+try {
+  elementStyle = document.createElement('div').style;
+} catch (e) {
+  elementStyle = null;
+}
 
 const vendor = (() => {
   const transformNames = {
@@ -30,6 +34,18 @@ const vendor = (() => {
     ms: 'msTransform',
     standard: 'transform'
   };
+
+  if (elementStyle === null) {
+    try {
+      elementStyle = document.createElement('div').style;
+    } catch (e) {
+      elementStyle = null;
+    }
+  }
+
+  if (elementStyle === null) {
+    return elementStyle['standard'];
+  }
 
   for (const key in transformNames) {
     if (elementStyle[transformNames[key]] !== undefined) {

--- a/src/views/MyExample.vue
+++ b/src/views/MyExample.vue
@@ -150,11 +150,11 @@
 
 <script>
 // import Waterfall from 'vue-waterfall-plugin';
-import { WaterfallNuxt } from '../plugin/waterfall';
+import Waterfall from '../plugin/waterfall';
 export default {
   name: 'App',
   components: {
-    WaterfallNuxt
+    Waterfall
   },
   data() {
     return {

--- a/src/views/MyExample.vue
+++ b/src/views/MyExample.vue
@@ -6,7 +6,7 @@
         v-infinite-scroll="load"
         infinite-scroll-disabled="disabled"
       >
-        <Waterfall
+        <WaterfallNuxt
           ref="waterfall"
           :list="list"
           :gutter="10"
@@ -59,7 +59,7 @@
               </div>
             </div>
           </template>
-        </Waterfall>
+        </WaterfallNuxt>
       </div>
       <p v-if="loading">加载中...</p>
       <p v-if="noMore">没有更多了</p>
@@ -150,11 +150,11 @@
 
 <script>
 // import Waterfall from 'vue-waterfall-plugin';
-import Waterfall from '../plugin/waterfall';
+import { WaterfallNuxt } from '../plugin/waterfall';
 export default {
   name: 'App',
   components: {
-    Waterfall
+    WaterfallNuxt
   },
   data() {
     return {

--- a/src/views/MyExample.vue
+++ b/src/views/MyExample.vue
@@ -6,7 +6,7 @@
         v-infinite-scroll="load"
         infinite-scroll-disabled="disabled"
       >
-        <WaterfallNuxt
+        <Waterfall
           ref="waterfall"
           :list="list"
           :gutter="10"
@@ -59,7 +59,7 @@
               </div>
             </div>
           </template>
-        </WaterfallNuxt>
+        </Waterfall>
       </div>
       <p v-if="loading">加载中...</p>
       <p v-if="noMore">没有更多了</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,6 +1538,13 @@ async-limiter@~1.0.0:
   resolved "https://registry.npm.taobao.org/async-limiter/download/async-limiter-1.0.1.tgz?cache=0&sync_timestamp=1574271725892&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fasync-limiter%2Fdownload%2Fasync-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=
 
+async-validator@~1.8.1:
+  version "1.8.5"
+  resolved "https://registry.npm.taobao.org/async-validator/download/async-validator-1.8.5.tgz?cache=0&sync_timestamp=1596623539220&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fasync-validator%2Fdownload%2Fasync-validator-1.8.5.tgz#dc3e08ec1fd0dddb67e60842f02c0cd1cec6d7f0"
+  integrity sha1-3D4I7B/Q3dtn5ghC8CwM0c7G1/A=
+  dependencies:
+    babel-runtime "6.x"
+
 async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.npm.taobao.org/async/download/async-2.6.3.tgz?cache=0&sync_timestamp=1582513244496&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fasync%2Fdownload%2Fasync-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
@@ -1590,6 +1597,11 @@ babel-eslint@^10.0.3:
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
 
+babel-helper-vue-jsx-merge-props@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.npm.taobao.org/babel-helper-vue-jsx-merge-props/download/babel-helper-vue-jsx-merge-props-2.0.3.tgz#22aebd3b33902328e513293a8e4992b384f9f1b6"
+  integrity sha1-Iq69OzOQIyjlEyk6jkmSs4T58bY=
+
 babel-loader@^8.0.6:
   version "8.0.6"
   resolved "https://registry.npm.taobao.org/babel-loader/download/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
@@ -1606,6 +1618,14 @@ babel-plugin-dynamic-import-node@^2.3.0:
   integrity sha1-8A9Qe9qjw+P/bn5emNkKesq5b38=
   dependencies:
     object.assign "^4.1.0"
+
+babel-runtime@6.x:
+  version "6.26.0"
+  resolved "https://registry.npm.taobao.org/babel-runtime/download/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -2440,6 +2460,11 @@ core-js-compat@^3.6.2, core-js-compat@^3.6.4:
     browserslist "^4.8.3"
     semver "7.0.0"
 
+core-js@^2.4.0:
+  version "2.6.11"
+  resolved "https://registry.npm.taobao.org/core-js/download/core-js-2.6.11.tgz?cache=0&sync_timestamp=1592817929546&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcore-js%2Fdownload%2Fcore-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha1-OIMUafmSK97Y7iHJ3EaYXgOZMIw=
+
 core-js@^3.6.4:
   version "3.6.4"
   resolved "https://registry.npm.taobao.org/core-js/download/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
@@ -2776,9 +2801,9 @@ deep-is@~0.1.3:
   resolved "https://registry.npm.taobao.org/deep-is/download/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^1.5.2:
+deepmerge@^1.2.0, deepmerge@^1.5.2:
   version "1.5.2"
-  resolved "https://registry.npm.taobao.org/deepmerge/download/deepmerge-1.5.2.tgz?cache=0&sync_timestamp=1572279556265&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdeepmerge%2Fdownload%2Fdeepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
+  resolved "https://registry.npm.taobao.org/deepmerge/download/deepmerge-1.5.2.tgz?cache=0&sync_timestamp=1572279720382&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdeepmerge%2Fdownload%2Fdeepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
   integrity sha1-EEmdhohEza1P7ghC34x/bwyVp1M=
 
 default-gateway@^4.2.0:
@@ -3033,6 +3058,18 @@ electron-to-chromium@^1.3.363:
   version "1.3.367"
   resolved "https://registry.npm.taobao.org/electron-to-chromium/download/electron-to-chromium-1.3.367.tgz#48abffcaa6591051b612ae70ddc657763ede2662"
   integrity sha1-SKv/yqZZEFG2Eq5w3cZXdj7eJmI=
+
+element-ui@^2.13.2:
+  version "2.13.2"
+  resolved "https://registry.npm.taobao.org/element-ui/download/element-ui-2.13.2.tgz#582bf47aaaaaafe23ea1958fae217a687ad06447"
+  integrity sha1-WCv0eqqqr+I+oZWPriF6aHrQZEc=
+  dependencies:
+    async-validator "~1.8.1"
+    babel-helper-vue-jsx-merge-props "^2.0.0"
+    deepmerge "^1.2.0"
+    normalize-wheel "^1.0.1"
+    resize-observer-polyfill "^1.5.0"
+    throttle-debounce "^1.0.1"
 
 elliptic@^6.0.0:
   version "6.5.2"
@@ -5621,6 +5658,11 @@ normalize-url@^3.0.0:
   resolved "https://registry.npm.taobao.org/normalize-url/download/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha1-suHE3E98bVd0PfczpPWXjRhlBVk=
 
+normalize-wheel@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npm.taobao.org/normalize-wheel/download/normalize-wheel-1.0.1.tgz#aec886affdb045070d856447df62ecf86146ec45"
+  integrity sha1-rsiGr/2wRQcNhWRH32Ls+GFG7EU=
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npm.taobao.org/npm-run-path/download/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -6784,6 +6826,11 @@ regenerate@^1.4.0:
   resolved "https://registry.npm.taobao.org/regenerate/download/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=
 
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.11.1.tgz?cache=0&sync_timestamp=1595456224955&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregenerator-runtime%2Fdownload%2Fregenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=
+
 regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
@@ -6940,6 +6987,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npm.taobao.org/requires-port/download/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.npm.taobao.org/resize-observer-polyfill/download/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha1-DpAg3T0hAkRY1OvSfiPkAmmBBGQ=
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -7849,6 +7901,11 @@ thread-loader@^2.1.3:
     loader-utils "^1.1.0"
     neo-async "^2.6.0"
 
+throttle-debounce@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.npm.taobao.org/throttle-debounce/download/throttle-debounce-1.1.0.tgz?cache=0&sync_timestamp=1597223654966&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fthrottle-debounce%2Fdownload%2Fthrottle-debounce-1.1.0.tgz#51853da37be68a155cb6e827b3514a3c422e89cd"
+  integrity sha1-UYU9o3vmihVctugns1FKPEIuic0=
+
 through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.npm.taobao.org/through2/download/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -8300,6 +8357,11 @@ vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.npm.taobao.org/vue-template-es2015-compiler/download/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha1-HuO8mhbsv1EYvjNLsV+cRvgvWCU=
+
+vue-waterfall-plugin@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npm.taobao.org/vue-waterfall-plugin/download/vue-waterfall-plugin-1.1.0.tgz?cache=0&sync_timestamp=1598000551518&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-waterfall-plugin%2Fdownload%2Fvue-waterfall-plugin-1.1.0.tgz#a4d87c74b72f1e36de5bbbadf1d645eb549ed592"
+  integrity sha1-pNh8dLcvHjbeW7ut8dZF61Se1ZI=
 
 vue@^2.6.11:
   version "2.6.11"


### PR DESCRIPTION
因为在考虑 SSR 的事情，所以进行了这个 PR。
基本原理是先让 Waterfall 组件先将列表元素渲染出来，待到客户端再渲染。这样可以使得搜索引擎爬虫可以爬取瀑布流数据。
唯一的改动是修改 dom.js。为了适应不同浏览器， dom.js 采用创造元素并判断方法来确定 transform 是否可用。但是在服务端，document 是不可用的。为此，简单的想法是每次使用前 catch，如果不存在说明位于非客户端，返回默认值。
此外，在 READ.md 添加了在 Nuxt 使用的方法，测试可行，但是存在污染全局 Vue 的风险，因为这相当于全局注入。